### PR TITLE
fix(lora): clamp loop index so depth-extrapolation does not crash

### DIFF
--- a/open_mythos/main.py
+++ b/open_mythos/main.py
@@ -576,7 +576,8 @@ class LoRAAdapter(nn.Module):
         Returns:
             Delta tensor of shape (B, T, dim) to be added to the block output
         """
-        s = self.scale(torch.tensor(loop_t, device=x.device))  # (rank,)
+        idx = min(loop_t, self.scale.num_embeddings - 1)  # clamp for depth extrapolation
+        s = self.scale(torch.tensor(idx, device=x.device))  # (rank,)
         down = self.down(x) * s  # (B, T, rank)
         return down @ self.B  # (B, T, dim)
 


### PR DESCRIPTION
## Summary

`RecurrentDepthTransformer.generate` documents that `n_loops` can be set higher than the training value to extrapolate to harder problems at inference time (depth-extrapolation). However, `LoRAAdapter.scale` is `nn.Embedding(max_loops, rank)` with `max_loops = cfg.max_loop_iters`, and `LoRAAdapter.forward` indexes it with the raw `loop_t`. When `n_loops > max_loop_iters` and ACT does not halt every position before `t == max_loops`, the lookup goes out of range and `generate` raises `IndexError: index out of range in self`.

This was masked in quick sanity runs because the random-initialized halting head often fires ACT within 1–2 iterations. Forcing the halt bias very negative (so `p_halt ≈ 0` and ACT never halts) reproduces the crash deterministically on both `attn_type="mla"` and `attn_type="gqa"`.

Fix: clamp `loop_t` to the last trained embedding (`num_embeddings - 1`). This keeps the per-loop LoRA delta well defined beyond training depth while preserving the intended depth-extrapolation behavior promised by `generate`'s docstring.

## Repro (before fix)

```python
import torch
from open_mythos.main import MythosConfig, OpenMythos

for attn in ("mla", "gqa"):
    torch.manual_seed(0)
    cfg = MythosConfig(
        vocab_size=1000, dim=256, n_heads=8, n_kv_heads=4,
        max_seq_len=128, max_loop_iters=4,
        n_experts=8, n_shared_experts=1, n_experts_per_tok=2,
        attn_type=attn, act_threshold=0.99,
    )
    m = OpenMythos(cfg)
    # Force p_halt ~ 0 so ACT never halts early
    for name, p in m.named_parameters():
        if "act.halt" in name:
            with torch.no_grad():
                p.fill_(-100.0) if p.dim() == 1 else p.zero_()
    ids = torch.randint(0, 1000, (2, 16))
    m.generate(ids, max_new_tokens=2, n_loops=8)  # IndexError on main
```

## Test plan

- [x] Repro the `IndexError` on `main` for both MLA and GQA with `n_loops=8 > max_loop_iters=4` when ACT is forced not to halt
- [x] After the fix, `generate(n_loops=8, max_loop_iters=4)` runs to completion on both attention variants
- [x] Compute-adaptive sanity: running `forward` at increasing `n_loops` shows logits evolving until ACT halts, then stabilizing — expected behavior
- [x] Existing example (`example.py`) still runs cleanly