### PR TITLE
Fix docs example and remove undefined exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ from open_mythos import (
     OpenMythos,
 )
 
-cfg = mythos_7b()  # returns a MythosConfig
+cfg = mythos_3b()  # returns a MythosConfig
 model = OpenMythos(cfg)
 
 total = sum(p.numel() for p in model.parameters())

--- a/open_mythos/__init__.py
+++ b/open_mythos/__init__.py
@@ -49,7 +49,5 @@ __all__ = [
     "mythos_100b",
     "mythos_500b",
     "mythos_1t",
-    "load_tokenizer",
-    "get_vocab_size",
     "MythosTokenizer",
 ]


### PR DESCRIPTION
## Summary
- replace the README variant example from `mythos_7b()` to `mythos_3b()`, which exists in `open_mythos/variants.py`
- remove `load_tokenizer` and `get_vocab_size` from `open_mythos/__init__.py` `__all__` because these symbols are not defined
- keep the public API/docs aligned to avoid import confusion for downstream users

## Test plan
- [ ] Run `python3 -m pytest -q test_main.py tests/test_tokenizer.py`
- [ ] Verify `from open_mythos import *` no longer advertises undefined names

Made with [Cursor](https://cursor.com)