### PR TITLE
fix: correct mythos_7b() to mythos_3b() in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ from open_mythos import (
     OpenMythos,
 )
 
-cfg = mythos_7b()  # returns a MythosConfig
+cfg = mythos_3b()  # returns a MythosConfig
 model = OpenMythos(cfg)
 
 total = sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
## Problem

The Model Variants section in README.md references `mythos_7b()`, which does not exist. The available variants are: `mythos_1b`, `mythos_3b`, `mythos_10b`, `mythos_50b`, `mythos_100b`, `mythos_500b`, and `mythos_1t`.

Anyone copy-pasting the example would get a `NameError`.

## Fix

Changed `mythos_7b()` to `mythos_3b()` — the closest valid variant.