### PR TITLE
fix: normalize torch version to >=2.1.0 across all dependency files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
-torch = "2.11.0"
+torch = ">=2.1.0"
 transformers = ">=4.40.0"
 datasets = ">=2.18.0"
 

--- a/training/requirements.txt
+++ b/training/requirements.txt
@@ -1,4 +1,4 @@
-torch>=2.11.0
+torch>=2.1.0
 datasets>=3.6.0
 loguru>=0.7.3
 open-mythos


### PR DESCRIPTION
## Problem

The torch version requirement is inconsistent across the three dependency files:

| File | Was |
|---|---|
| `pyproject.toml` | `torch = "2.11.0"` (exact pin to a non-existent version) |
| `requirements.txt` | `torch>=2.1.0` |
| `training/requirements.txt` | `torch>=2.11.0` (also non-existent) |

`torch 2.11.0` does not exist on PyPI — the latest 2.x releases follow `2.1.x`, `2.2.x`, `2.3.x`, etc. This causes install failures for anyone using `pyproject.toml` or the training requirements.

## Fix

Aligned all three files to `torch>=2.1.0`, matching the existing `requirements.txt` convention.