### PR TITLE
Test/lint baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install Poetry
+        run: |
+          pip install "poetry-core>=1.0.0" poetry
+          poetry config virtualenvs.in-project true
+
+      - name: Cache Poetry virtualenv
+        uses: actions/cache@v5
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-3.10-${{ hashFiles('pyproject.toml') }}
+
+      - name: Install dependencies
+        run: |
+          poetry install --with lint,test
+
+      - name: Check formatting (black)
+        run: |
+          poetry run black --check .
+
+      - name: Lint (ruff)
+        run: |
+          poetry run ruff check .
+
+      # Tests require upstream test fixes (freqs_cis slicing, LTI bound).
+      # Enable once PR #42 is merged.
+      # - name: Run tests (pytest)
+      #   run: |
+      #     poetry run pytest -q --tb=short

--- a/example.py
+++ b/example.py
@@ -1,7 +1,6 @@
 import torch
 from open_mythos.main import OpenMythos, MythosConfig
 
-
 attn_type = "mla"  # or "gqa"
 
 base = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 
 
 [tool.poetry.dependencies]
-python = ">=3.10,<4.0"
+python = ">=3.10,<3.15"
 torch = "2.11.0"
 transformers = ">=4.40.0"
 datasets = ">=2.18.0"

--- a/training/3b_fine_web_edu.py
+++ b/training/3b_fine_web_edu.py
@@ -34,7 +34,6 @@ from open_mythos.main import TransformerBlock, RecurrentBlock
 from open_mythos.variants import mythos_3b
 from open_mythos.tokenizer import MythosTokenizer
 
-
 # ---------------------------------------------------------------------------
 # Dataset
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Add CI to check formatting (black) and linting (ruff), using poetry per contents of pyproject.toml.
Testing is commented out (see PR #42).
Adjusting python version range to avoid clashing with triton requirements (so poetry will be able to resolve).