### PR TITLE
docs(readme): fix spectral-radius example for 1-D diagonal A

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ out = model.generate(ids, max_new_tokens=8, n_loops=8)
 print(f"[{attn_type.upper()}] Generated shape: {out.shape}")
 
 A = model.recurrent.injection.get_A()
-rho = torch.linalg.eigvals(A).abs().max().item()
+# get_A() returns the diagonal of a diagonal state matrix (shape: (dim,)),
+# so its eigenvalues are simply its entries.
+rho = A.abs().max().item()
 print(
     f"[{attn_type.upper()}] Spectral radius ρ(A) = {rho:.4f} (must be < 1)"
 )


### PR DESCRIPTION
## Summary

The README's stability-check snippet errors when run as written:

\`\`\`python
A = model.recurrent.injection.get_A()
rho = torch.linalg.eigvals(A).abs().max().item()
# RuntimeError: linalg.eig: The input tensor A must have at least 2 dimensions.
\`\`\`

\`LTIInjection.get_A()\` returns a 1-D tensor of shape \`(dim,)\` — the diagonal of a diagonal state matrix — so \`torch.linalg.eigvals\` rejects it. The eigenvalues of a diagonal matrix are simply its diagonal entries, so the correct (and simpler) form is \`A.abs().max()\`.

Reproduced on a fresh install (\`open-mythos==0.5.0\`, Python 3.11, PyTorch 2.8) using the exact README example. After the fix the example runs end-to-end and prints \`ρ(A) = 0.3679\` (= \`exp(-1)\` at init, matching the \`log_dt = log_A = 0\` parameterization).

## Test plan

- [x] Ran the README snippet on a clean install — errored before, prints \`ρ(A) = 0.3679\` after
- [x] Cross-checked against \`torch.linalg.eigvals(torch.diag(A)).abs().max()\` — same value
- [x] Verified \`ρ < 1\` holds at init by construction (\`A_i = exp(-exp(log_dt + log_A))\`)